### PR TITLE
Support root-level config (facilitates `extensions` obj)

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,15 +27,34 @@ function mergeReferences (oldRefs, newRefs) {
     .value();
 }
 
-module.exports = function (source) {
-  this.cacheable();
 
-  const options = loaderUtils.parseQuery(this.query);
+/**
+ * Parse and merge options from:
+ *   - config-level object (`angularGettextExtractLoader`)
+ *   - query string
+ */
+function getOptions(loaderContext) {
+  const config = loaderContext.options['angularGettextExtractLoader'];
+  const query = loaderUtils.parseQuery(loaderContext.query);
+  const options = _.assign({}, config, query);
+  
+  // Parse `extensions` option. Allows for custom file schemes.
+  if (_.isString(options.extensions)) {
+    options.extensions = JSON.parse(options.extensions);
+  }
 
   if (!options.pofile) {
     options.pofile = 'template.pot';
   }
 
+  return options;
+}
+
+
+module.exports = function (source) {
+  this.cacheable();
+
+  const options = getOptions(this);
   var po;
 
   try {


### PR DESCRIPTION
This will allow you to create a root-level config object on your webpack config. Addresses issue #1 by allowing you to merge in an `extensions` object.

Example:

``` js
var webpack = require('webpack');

const config = {
  context: __dirname + '/app',
  entry: { ... },
  output: { ... },
  module: {
    loaders: [
      {
        test: /\.ts$/,
        loaders: [
          'angular-gettext-extract',
          'ts',
        ]
      },
      {
        test: /app.*\.html$/,
        exclude: [/index.html/],
        loaders: [
          'ngtemplate?relativeTo=' + __dirname + '/app',
          'html',
          'angular-gettext-extract'
        ]
      }
    ]
  },
  angularGettextExtractLoader: {
    pofile: 'po/template.pot',
    extensions: {
      ts: 'js',
      html: 'html'
    }
  }
};

module.exports = config;
```
