### PR TITLE
update plugin to work with webpack 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
-# angular-gettext-extract-loader
 Loader to extract gettext strings from an angular project.
+
+## webpack
+
+    compaitable with webpack ^4.0.0
 
 ## Installation
 

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function mergeReferences (oldRefs, newRefs) {
  *   - query string
  */
 function getOptions(loaderContext) {
-  const config = loaderContext.options['angularGettextExtractLoader'];
+  const config = loaderContext.rootContext['angularGettextExtractLoader'];
   const query = loaderUtils.parseQuery(loaderContext.query);
   const options = _.assign({}, config, query);
   
@@ -71,7 +71,7 @@ module.exports = function (source) {
 
   const extractor = new Extractor(options);
 
-  const filename = path.relative(this.options.context, this.resourcePath);
+  const filename = path.relative(this.rootContext, this.resourcePath);
 
   extractor.parse(filename, source);
 

--- a/index.js
+++ b/index.js
@@ -13,18 +13,18 @@ function matches (oldRef, newRef) {
  * Merge new references with old references; ignore old references from the same file.
  */
 function mergeReferences (oldRefs, newRefs) {
-  const _newRefs = _(newRefs);
+    const _newRefs = _(newRefs);
 
-  return _(oldRefs)
-    .reject(function (oldRef) {
-      return _newRefs.any(function (newRef) {
-        return matches(oldRef, newRef);
-      });
-    })
-    .concat(newRefs)
-    .uniq()
-    .sort()
-    .value();
+    return _(oldRefs)
+        .reject(function (oldRef) {
+            return _newRefs.any(function (newRef) {
+                return matches(oldRef, newRef);
+            });
+        })
+        .concat(newRefs)
+        .uniq()
+        .sort()
+        .value();
 }
 
 
@@ -34,63 +34,63 @@ function mergeReferences (oldRefs, newRefs) {
  *   - query string
  */
 function getOptions(loaderContext) {
-  const config = loaderContext.rootContext['angularGettextExtractLoader'];
-  const query = loaderUtils.parseQuery(loaderContext.query);
-  const options = _.assign({}, config, query);
-  
-  // Parse `extensions` option. Allows for custom file schemes.
-  if (_.isString(options.extensions)) {
-    options.extensions = JSON.parse(options.extensions);
-  }
+    const config = loaderContext.rootContext['angularGettextExtractLoader'];
+    const query = loaderUtils.getOptions(loaderContext);
+    // Need polyfill for IE, you could replace it back to lodash _({}, ..)
+    const options = Object.assign({}, config, query);
 
-  if (!options.pofile) {
-    options.pofile = 'template.pot';
-  }
+    // Parse `extensions` option. Allows for custom file schemes.
+    if (typeof options.extensions === 'string') {
+        options.extensions = JSON.parse(options.extensions);
+    }
 
-  return options;
+    if (!options.pofile) {
+        options.pofile = 'template.pot';
+    }
+
+    return options;
 }
 
 
 module.exports = function (source) {
-  this.cacheable();
+    this.cacheable();
 
-  const options = getOptions(this);
-  var po;
+    const options = getOptions(this);
+    var po;
 
-  try {
-    const s = fs.readFileSync(options.pofile, 'utf8');
-
-    po = PO.parse(s);
-  } catch (e) {
-    if (e.code === 'ENOENT') {
-      po = new PO();
-    } else {
-      throw new Error('Problem loading pofile: ' + e);
-    }
-  }
-
-  const extractor = new Extractor(options);
-
-  const filename = path.relative(this.rootContext, this.resourcePath);
-
-  extractor.parse(filename, source);
-
-  _.each(po.items, function (item) {
-    const context = item.msgctxt || '$$noContext';
-
-    if (!extractor.strings[item.msgid]) {
-      extractor.strings[item.msgid] = {};
+    try {
+        const s = fs.readFileSync(options.pofile, 'utf8');
+        po = PO.parse(s);
+    } catch (e) {
+        if (e.code === 'ENOENT') {
+            po = new PO();
+        } else {
+            throw new Error('Problem loading pofile: ' + e);
+        }
     }
 
-    const existing = extractor.strings[item.msgid][context];
+    const extractor = new Extractor(options);
 
-    if (existing) {
-      existing.comments = _.uniq(existing.comments.concat(item.comments)).sort();
-      existing.references = mergeReferences(item.references, existing.references);
-    } else {
-      extractor.strings[item.msgid][context] = item;
-    }
-  });
+    const filename = path.relative(this.rootContext, this.resourcePath);
+
+    extractor.parse(filename, source);
+
+    po.items.forEach(function (item) {
+        const context = item.msgctxt || '$$noContext';
+
+        if (!extractor.strings[item.msgid]) {
+            extractor.strings[item.msgid] = {};
+        }
+
+        const existing = extractor.strings[item.msgid][context];
+
+        if (existing) {
+            existing.comments = _.uniq(existing.comments.concat(item.comments)).sort();
+            existing.references = mergeReferences(item.references, existing.references);
+        } else {
+            extractor.strings[item.msgid][context] = item;
+        }
+    });
 
   fs.writeFileSync(options.pofile, extractor.toString());
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "angular-gettext-tools": "^2.1.4",
-    "loader-utils": "^0.2.11",
+    "loader-utils": "1.1.0",
     "lodash": "^3.10.1",
     "pofile": "^1.0.0"
   }


### PR DESCRIPTION
We use angular 6.1.1, webpack 4.16.5 and typescript 3.0.1
This update allowed us to use angular-gettext-extract-loader to extract string ids from .js, .ts and .html files.

The loader uses angular-gettext-tools lib. You will need to upgrade dependencies there.
Fork it and update dependencies (no other updates needed):
 ```
   "typescript": "3.0.1",
   "typescript-eslint-parser": "18.0.0"
```

With changes listed here we run string ids extraction for our angular 6 project, that contains angular 1.6 project. Everything works as expected. 

Hope it helps someone. Thanks =)

p.s. probably, this update will break plugin for webpack ^3.